### PR TITLE
Add handling of missing "service" object for port.

### DIFF
--- a/nmap_xml_parser.py
+++ b/nmap_xml_parser.py
@@ -69,7 +69,10 @@ def get_host_data(root):
                 
                 proto = port.attrib['protocol']
                 port_id = port.attrib['portid']
-                service = port.findall('service')[0].attrib['name']
+                try:
+                    service = port.findall('service')[0].attrib['name']
+                except (IndexError, KeyError):
+                    service = 'unknown'
                 try:
                     product = port.findall('service')[0].attrib['product']
                 except (IndexError, KeyError):


### PR DESCRIPTION
If there is no "service" object, this fixes the skipping-over which is completely dropping that open port from the output.

Example:
```
<ports><extraports state="closed" count="33">
<extrareasons reason="conn-refused" count="33"/>
</extraports>
<port protocol="tcp" portid="80"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="http" method="table" conf="3"/></port>
<port protocol="tcp" portid="4780"><state state="open" reason="syn-ack" reason_ttl="0"/></port>
</ports>
```

Without my fix, the port 4780 is completely skipped.